### PR TITLE
Rename parent domain attribute to subdomainOf

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1269,6 +1269,15 @@ but there will always be one ultimate owner.
 | ------------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
 | [`Group`](#kind-group) (default), [`User`](#kind-user) | Same as this entity, typically `default`   | [`ownerOf`, and reverse `ownedBy`](well-known-relations.md#ownedby-and-ownerof) |
 
+### `spec.subdomainOf` [optional]
+
+An [entity reference](references.md#string-references) to another domain of
+which the domain is a part, e.g. `audio`. This field is optional.
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
+| [`Domain`](#kind-domain)                | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
+
 ## Kind: Location
 
 Describes the following entity kind:

--- a/packages/catalog-model/examples/domains/artists-domain.yaml
+++ b/packages/catalog-model/examples/domains/artists-domain.yaml
@@ -11,4 +11,4 @@ metadata:
       icon: dashboard
 spec:
   owner: team-a
-  domain: audio
+  subdomainOf: audio

--- a/packages/catalog-model/examples/domains/playback-domain.yaml
+++ b/packages/catalog-model/examples/domains/playback-domain.yaml
@@ -5,3 +5,4 @@ metadata:
   description: Everything related to audio playback
 spec:
   owner: user:frank.tiernan
+  subdomainOf: audio

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
@@ -31,7 +31,7 @@ describe('DomainV1alpha1Validator', () => {
       },
       spec: {
         owner: 'me',
-        domain: 'parent',
+        subdomainOf: 'parent-domain',
       },
     };
   });
@@ -70,18 +70,18 @@ describe('DomainV1alpha1Validator', () => {
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 
-  it('accepts missing domain', async () => {
-    delete (entity as any).spec.domain;
+  it('accepts missing subdomainOf', async () => {
+    delete (entity as any).spec.subdomainOf;
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects wrong domain', async () => {
-    (entity as any).spec.domain = 7;
-    await expect(validator.check(entity)).rejects.toThrow(/domain/);
+  it('rejects wrong subdomainOf', async () => {
+    (entity as any).spec.subdomainOf = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/subdomainOf/);
   });
 
-  it('rejects empty domain', async () => {
-    (entity as any).spec.domain = '';
-    await expect(validator.check(entity)).rejects.toThrow(/domain/);
+  it('rejects empty subdomainOf', async () => {
+    (entity as any).spec.subdomainOf = '';
+    await expect(validator.check(entity)).rejects.toThrow(/subdomainOf/);
   });
 });

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -32,7 +32,7 @@ export interface DomainEntityV1alpha1 extends Entity {
   kind: 'Domain';
   spec: {
     owner: string;
-    domain?: string;
+    subdomainOf?: string;
   };
 }
 

--- a/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
@@ -12,7 +12,7 @@
       },
       "spec": {
         "owner": "artist-relations-team",
-        "domain": "artists"
+        "subdomainOf": "audio"
       }
     }
   ],
@@ -40,10 +40,10 @@
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
             },
-            "domain": {
+            "subdomainOf": {
               "type": "string",
-              "description": "An entity reference to the domain that the system belongs to.",
-              "examples": ["artists"],
+              "description": "An entity reference to another domain of which the domain is a part.",
+              "examples": ["audio"],
               "minLength": 1
             }
           }

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
@@ -418,12 +418,13 @@ describe('BuiltinKindsEntityProcessor', () => {
         metadata: { name: 'n' },
         spec: {
           owner: 'o',
+          subdomainOf: 'p',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit).toHaveBeenCalledTimes(4);
       expect(emit).toHaveBeenCalledWith({
         type: 'relation',
         relation: {
@@ -438,6 +439,22 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Domain', namespace: 'default', name: 'n' },
           type: 'ownedBy',
           target: { kind: 'Group', namespace: 'default', name: 'o' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'n' },
+          type: 'partOf',
+          target: { kind: 'Domain', namespace: 'default', name: 'p' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'p' },
+          type: 'hasPart',
+          target: { kind: 'Domain', namespace: 'default', name: 'n' },
         },
       });
     });

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
@@ -298,6 +298,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
       );
+      doEmit(
+        domain.spec.subdomainOf,
+        { defaultKind: 'Domain', defaultNamespace: selfRef.namespace },
+        RELATION_PART_OF,
+        RELATION_HAS_PART,
+      );
     }
 
     return entity;


### PR DESCRIPTION
- Changes `domain` to `subdomainOf` to be more consistent with other entities (Alternatively, `parent` can be used as in the `Group` entity kind)
- Emits `hasPart` and `partOf` relations for parent and child domain
- Documents the attribute